### PR TITLE
Ignore Rust target/ output

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,9 @@ lerna-debug.log*
 node_modules
 dist
 dist-ssr
+
+# Rust / Cargo (e.g. contracts)
+target/
 *.local
 
 # Editor directories and files


### PR DESCRIPTION
## Summary
- Add 	arget/ to .gitignore so Rust/Cargo/Soroban build artifacts aren’t tracked.

## Test plan
- [ ] Confirm contracts/target is ignored (not tracked).


Made with [Cursor](https://cursor.com)