### PR TITLE
Centralize fee calculations

### DIFF
--- a/src/components/TransactionItem.tsx
+++ b/src/components/TransactionItem.tsx
@@ -3,6 +3,7 @@ import { Transaction } from '@/types';
 import { StatusBadge } from './StatusBadge';
 import { cn } from '@/lib/utils';
 import { formatDistanceToNow } from 'date-fns';
+import { splitFee } from '@/lib/fees';
 
 interface TransactionItemProps {
   transaction: Transaction;
@@ -12,6 +13,7 @@ interface TransactionItemProps {
 
 export function TransactionItem({ transaction, onClick, showDetailedView = false }: TransactionItemProps) {
   const isSend = transaction.type === 'send';
+  const feeSplit = splitFee(transaction.fee, { network: 0.1, service: 0.9 });
 
   return (
     <button
@@ -92,11 +94,11 @@ export function TransactionItem({ transaction, onClick, showDetailedView = false
                 </div>
                 <div className="flex justify-between">
                   <span className="text-muted-foreground">Network fee</span>
-                  <span className="font-medium">${(transaction.fee * 0.1).toFixed(3)}</span>
+                  <span className="font-medium">${feeSplit.networkFee.toFixed(3)}</span>
                 </div>
                 <div className="flex justify-between">
                   <span className="text-muted-foreground">Service fee</span>
-                  <span className="font-medium">${(transaction.fee * 0.9).toFixed(2)}</span>
+                  <span className="font-medium">${feeSplit.serviceFee.toFixed(2)}</span>
                 </div>
                 <div className="border-t border-border/50 pt-1 mt-2">
                   <div className="flex justify-between font-semibold">

--- a/src/data/mockData.ts
+++ b/src/data/mockData.ts
@@ -422,16 +422,4 @@ export const oxxoLocations: PickupLocation[] = [
   }
 ];
 
-export const calculateFees = (amount: number): { networkFee: number; serviceFee: number; totalFee: number; recipientGets: number } => {
-  const networkFee = 0.001; // Stellar network fee (near zero)
-  const serviceFee = amount * 0.002; // 0.2% service fee
-  const totalFee = networkFee + serviceFee;
-  const recipientGets = amount - totalFee;
-  
-  return {
-    networkFee: Math.round(networkFee * 100) / 100,
-    serviceFee: Math.round(serviceFee * 100) / 100,
-    totalFee: Math.round(totalFee * 100) / 100,
-    recipientGets: Math.round(recipientGets * 100) / 100,
-  };
-};
+// Fee logic moved to `src/lib/fees.ts`.

--- a/src/lib/fees.ts
+++ b/src/lib/fees.ts
@@ -1,0 +1,102 @@
+import type { FundingMethod, WithdrawalMethod } from '@/types';
+
+export interface PercentageFixedFees {
+  percentage?: number; // percent, e.g. 2.9
+  fixed?: number; // USD
+}
+
+export interface MethodFeeResult {
+  fee: number;
+  total: number;
+  net: number;
+}
+
+export interface MethodFeeWithRecipientResult extends MethodFeeResult {
+  recipient: number;
+  exchangeRate: number;
+  currency: string;
+}
+
+export interface SendFeeBreakdown {
+  networkFee: number;
+  serviceFee: number;
+  totalFee: number;
+  recipientGets: number;
+}
+
+const round2 = (n: number) => Math.round(n * 100) / 100;
+const round4 = (n: number) => Math.round(n * 10000) / 10000;
+
+export interface SendFeePolicy {
+  /** Flat network fee, in the same units as amount (USDC). */
+  networkFee: number;
+  /** Service fee rate as decimal (e.g. 0.002 for 0.2%). */
+  serviceRate: number;
+}
+
+export const DEFAULT_SEND_FEE_POLICY: SendFeePolicy = {
+  networkFee: 0.001,
+  serviceRate: 0.002,
+};
+
+export function calculateSendFees(amount: number, policy: SendFeePolicy = DEFAULT_SEND_FEE_POLICY): SendFeeBreakdown {
+  const safeAmount = Number.isFinite(amount) ? Math.max(0, amount) : 0;
+  const networkFee = Math.max(0, policy.networkFee);
+  const serviceFee = safeAmount * Math.max(0, policy.serviceRate);
+  const totalFee = networkFee + serviceFee;
+  const recipientGets = Math.max(0, safeAmount - totalFee);
+
+  return {
+    networkFee: round4(networkFee),
+    serviceFee: round2(serviceFee),
+    totalFee: round2(totalFee),
+    recipientGets: round2(recipientGets),
+  };
+}
+
+export function splitFee(totalFee: number, weights: { network: number; service: number }) {
+  const total = Number.isFinite(totalFee) ? Math.max(0, totalFee) : 0;
+  const wNet = Math.max(0, weights.network);
+  const wSvc = Math.max(0, weights.service);
+  const wSum = wNet + wSvc || 1;
+
+  const networkFee = total * (wNet / wSum);
+  const serviceFee = total - networkFee;
+  return { networkFee: round4(networkFee), serviceFee: round2(serviceFee), totalFee: round2(total) };
+}
+
+export function calculateMethodFees(amount: number, fees: PercentageFixedFees): MethodFeeResult {
+  const safeAmount = Number.isFinite(amount) ? Math.max(0, amount) : 0;
+  const fixed = Math.max(0, fees.fixed ?? 0);
+  const pct = Math.max(0, fees.percentage ?? 0);
+  const fee = fixed + (safeAmount * pct) / 100;
+  return {
+    fee: round2(fee),
+    total: round2(safeAmount + fee),
+    net: round2(safeAmount),
+  };
+}
+
+export function calculateFundingFees(amount: number, method: Pick<FundingMethod, 'fees'>): MethodFeeResult {
+  return calculateMethodFees(amount, method.fees);
+}
+
+export function calculateWithdrawalFees(params: {
+  amount: number;
+  method: Pick<WithdrawalMethod, 'fees'>;
+  exchangeRate: number;
+  currency: string;
+}): MethodFeeWithRecipientResult {
+  const base = calculateMethodFees(params.amount, params.method.fees);
+  const net = Math.max(0, base.net - base.fee);
+  const recipient = net * (Number.isFinite(params.exchangeRate) ? params.exchangeRate : 1);
+  return {
+    ...base,
+    total: round2(Number.isFinite(params.amount) ? Math.max(0, params.amount) : 0),
+    net: round2(net),
+    recipient: round2(recipient),
+    exchangeRate: params.exchangeRate,
+    currency: params.currency,
+  };
+}
+

--- a/src/pages/AddFunds.tsx
+++ b/src/pages/AddFunds.tsx
@@ -8,6 +8,7 @@ import { BottomNav } from '@/components/BottomNav';
 import { useAuth } from '@/contexts/AuthContext';
 import { fundingMethods } from '@/data/mockData';
 import { FundingMethod } from '@/types';
+import { calculateFundingFees } from '@/lib/fees';
 import { 
   ArrowLeft, 
   Building2, 
@@ -53,19 +54,8 @@ export default function AddFunds() {
   );
 
   const fees = useMemo(() => {
-    if (!selectedMethod || !amount) return { fee: 0, total: parseFloat(amount) || 0 };
-    
-    const parsedAmount = parseFloat(amount) || 0;
-    let fee = 0;
-    
-    if (selectedMethod.fees.fixed) fee += selectedMethod.fees.fixed;
-    if (selectedMethod.fees.percentage) fee += (parsedAmount * selectedMethod.fees.percentage / 100);
-    
-    return {
-      fee: Math.round(fee * 100) / 100,
-      total: Math.round((parsedAmount + fee) * 100) / 100,
-      net: parsedAmount
-    };
+    if (!selectedMethod || !amount) return { fee: 0, total: parseFloat(amount) || 0, net: parseFloat(amount) || 0 };
+    return calculateFundingFees(parseFloat(amount) || 0, selectedMethod);
   }, [selectedMethod, amount]);
 
   const handleMethodSelect = (method: FundingMethod) => {

--- a/src/pages/SendMoney.tsx
+++ b/src/pages/SendMoney.tsx
@@ -11,8 +11,9 @@ import { CompliancePreCheck } from '@/components/ComplianceCheck';
 import { useAuth } from '@/contexts/AuthContext';
 import { useWallet } from '@/contexts/WalletContext';
 import { useCompliance } from '@/contexts/ComplianceContext';
-import { contacts, calculateFees } from '@/data/mockData';
+import { contacts } from '@/data/mockData';
 import { Contact, TransactionPreview } from '@/types';
+import { calculateSendFees } from '@/lib/fees';
 import { ArrowLeft, Search, DollarSign, Send, CheckCircle2, UserPlus, Mail, Phone, MessageCircle, Shield, Zap, Globe2, Star, Clock, Wallet, MapPin, AlertTriangle } from 'lucide-react';
 import { toast } from 'sonner';
 
@@ -61,7 +62,7 @@ export default function SendMoney() {
 
   const fees = useMemo(() => {
     const parsedAmount = parseFloat(amount) || 0;
-    return calculateFees(parsedAmount);
+    return calculateSendFees(parsedAmount);
   }, [amount]);
 
   const handleSelectContact = (contact: Contact) => {

--- a/src/pages/Withdraw.tsx
+++ b/src/pages/Withdraw.tsx
@@ -8,6 +8,7 @@ import { BottomNav } from '@/components/BottomNav';
 import { useAuth } from '@/contexts/AuthContext';
 import { withdrawalMethods, oxxoLocations, contacts } from '@/data/mockData';
 import { WithdrawalMethod, PickupLocation, Contact } from '@/types';
+import { calculateWithdrawalFees } from '@/lib/fees';
 import { 
   ArrowLeft, 
   MapPin, 
@@ -75,24 +76,17 @@ export default function Withdraw() {
     : { rate: 1, currency: 'USD' };
 
   const fees = useMemo(() => {
-    if (!selectedMethod || !amount) return { fee: 0, total: parseFloat(amount) || 0, recipient: 0 };
-    
-    const parsedAmount = parseFloat(amount) || 0;
-    let fee = 0;
-    
-    if (selectedMethod.fees.fixed) fee += selectedMethod.fees.fixed;
-    if (selectedMethod.fees.percentage) fee += (parsedAmount * selectedMethod.fees.percentage / 100);
-    
-    const recipientAmount = (parsedAmount - fee) * recipientExchange.rate;
-    
-    return {
-      fee: Math.round(fee * 100) / 100,
-      total: parsedAmount,
-      net: Math.round((parsedAmount - fee) * 100) / 100,
-      recipient: Math.round(recipientAmount * 100) / 100,
+    if (!selectedMethod || !amount) {
+      const a = parseFloat(amount) || 0;
+      return { fee: 0, total: a, net: a, recipient: 0, exchangeRate: recipientExchange.rate, currency: recipientExchange.currency };
+    }
+
+    return calculateWithdrawalFees({
+      amount: parseFloat(amount) || 0,
+      method: selectedMethod,
       exchangeRate: recipientExchange.rate,
-      currency: recipientExchange.currency
-    };
+      currency: recipientExchange.currency,
+    });
   }, [selectedMethod, amount, recipientExchange]);
 
   const handleRecipientSelect = (contact: Contact) => {


### PR DESCRIPTION
Closes #8

---

## Summary\n- Add src/lib/fees.ts as the single place for fee computation (send fees + method fixed/percent fees).\n- Update Send/AddFunds/Withdraw/TransactionItem to use shared fee helpers.\n- Remove legacy calculateFees from mock data.\n\n## Test plan\n- [ ] Send Money shows same fee breakdown as before\n- [ ] Add Funds and Withdraw totals/fees match previous behavior\n- [ ] 
px tsc -p tsconfig.json --noEmit\n

Made with [Cursor](https://cursor.com)