### PR TITLE
feat: RBAC, fee transparency, transaction search, transfer integratio…

### DIFF
--- a/backend/src/app.ts
+++ b/backend/src/app.ts
@@ -7,6 +7,7 @@ import transferRoutes from './routes/transfers';
 import escrowRoutes from './routes/escrow';
 import authRoutes from './routes/auth';
 import activityRoutes from './routes/activity';
+import adminRoutes from './routes/admin';
 import { config } from './config';
 import { logger } from './logger';
 import { createContainer } from './container';
@@ -47,6 +48,7 @@ export async function buildApp() {
   await app.register(activityRoutes, { prefix });
   await app.register(transferRoutes, { prefix });
   await app.register(escrowRoutes, { prefix });
+  await app.register(adminRoutes, { prefix });
 
   app.addHook('onClose', async () => {
     logger.info('Server shutting down');

--- a/backend/src/auth/sessionStore.ts
+++ b/backend/src/auth/sessionStore.ts
@@ -79,6 +79,7 @@ export function createMariaSession(): Session {
     hasWallet: true,
     onboardingCompleted: true,
     transactionSigningSecret: createTransactionSigningSecret(),
+    role: 'admin',
     user,
   };
   saveSession(session);

--- a/backend/src/auth/sessionTypes.ts
+++ b/backend/src/auth/sessionTypes.ts
@@ -14,6 +14,8 @@ export interface PublicUser {
   createdAt: string;
 }
 
+export type UserRole = 'admin' | 'user';
+
 export interface Session {
   id: string;
   email?: string;
@@ -22,6 +24,7 @@ export interface Session {
   hasWallet: boolean;
   onboardingCompleted: boolean;
   transactionSigningSecret: string;
+  role?: UserRole;
   user?: PublicUser;
 }
 
@@ -29,4 +32,5 @@ export interface JwtSessionPayload {
   sub: string;
   verified: boolean;
   hasWallet: boolean;
+  role?: UserRole;
 }

--- a/backend/src/container.ts
+++ b/backend/src/container.ts
@@ -5,6 +5,7 @@ import { ComplianceService } from './modules/compliance/complianceService';
 import { FraudService } from './modules/fraud/fraudService';
 import { createDemoNotifications } from './modules/notifications/demoNotifications';
 import { NotificationService } from './modules/notifications/notificationService';
+import { AccessGuardService } from './modules/rbac/accessGuardService';
 import { SystemHealthService } from './modules/system/systemHealthService';
 import { createDemoTransfers } from './modules/transfers/demoTransfers';
 import { InMemoryTransferRepository } from './modules/transfers/inMemoryTransferRepository';
@@ -26,6 +27,7 @@ export interface AppContainer {
     activity: ActivityService;
     health: SystemHealthService;
     contracts: ContractService;
+    accessGuard: AccessGuardService;
   };
 }
 
@@ -41,14 +43,18 @@ export function createContainer(): AppContainer {
   const transfers = new TransferLifecycle(transferRepository, wallets, compliance, fraud, eventBus);
   const transferQueue = new TransferQueue(transfers, eventBus);
   const health = new SystemHealthService(compliance, wallets);
+  const accessGuard = new AccessGuardService();
 
   eventBus.subscribe<{ userId: string }>('transfer.created', (event) => {
     activity.invalidateUser(event.payload.userId);
   });
-  eventBus.subscribe<{ userId: string }>('transfer.settled', async (event) => {
-    activity.invalidateUser(event.payload.userId);
-    await notifications.notifyTransferSettled(event.payload);
-  });
+  eventBus.subscribe<{ userId: string; transferId: string; amount: number; recipientName: string }>(
+    'transfer.settled',
+    async (event) => {
+      activity.invalidateUser(event.payload.userId);
+      await notifications.notifyTransferSettled(event.payload);
+    },
+  );
   eventBus.subscribe<{ userId: string; amount: number; recipientName: string; transferId: string; error?: string }>(
     'transfer.failed',
     async (event) => {
@@ -83,6 +89,7 @@ export function createContainer(): AppContainer {
       activity,
       health,
       contracts,
+      accessGuard,
     },
   };
 }

--- a/backend/src/middleware/requireRole.ts
+++ b/backend/src/middleware/requireRole.ts
@@ -1,0 +1,49 @@
+import type { FastifyReply, FastifyRequest } from 'fastify';
+import { getSession } from '../auth/sessionStore';
+import type { JwtSessionPayload, UserRole } from '../auth/sessionTypes';
+
+/**
+ * Middleware factory that restricts a route to users whose session role matches
+ * `required`.  Admins pass all role checks automatically.
+ *
+ * Usage:
+ *   fastify.post('/admin/...', { preHandler: [requireVerifiedSession, requireRole('admin')] }, handler)
+ */
+export function requireRole(required: UserRole) {
+  return async (request: FastifyRequest, reply: FastifyReply): Promise<void> => {
+    const payload = request.user as JwtSessionPayload;
+    const session = getSession(payload.sub);
+    if (!session) {
+      await reply.code(401).send({ error: 'Session expired' });
+      return;
+    }
+    const role = session.role ?? 'user';
+    if (role !== required && role !== 'admin') {
+      await reply.code(403).send({ error: 'Insufficient permissions', required });
+      return;
+    }
+  };
+}
+
+/**
+ * Middleware that checks the Access Guard allow-list.
+ * Blocks non-admin users when the gate is closed or they are explicitly blocked.
+ *
+ * Must be placed AFTER requireVerifiedSession so `request.user` is populated.
+ */
+export async function requireAccessGuard(
+  request: FastifyRequest,
+  reply: FastifyReply,
+): Promise<void> {
+  const payload = request.user as JwtSessionPayload;
+  const session = getSession(payload.sub);
+  if (!session?.user) return; // requireVerifiedSession already guards this
+
+  const accessGuard = (request.server as any).container?.services?.accessGuard;
+  if (!accessGuard) return; // safety — never block if service unavailable
+
+  const allowed = accessGuard.check(session.user.id);
+  if (!allowed) {
+    await reply.code(403).send({ error: 'Access denied by system policy' });
+  }
+}

--- a/backend/src/modules/activity/activityService.ts
+++ b/backend/src/modules/activity/activityService.ts
@@ -26,6 +26,17 @@ export interface ActivityTransactionDto {
   };
 }
 
+export interface TransactionSearchParams {
+  q?: string;
+  status?: 'pending' | 'completed' | 'failed';
+  dateFrom?: string;
+  dateTo?: string;
+  amountMin?: number;
+  amountMax?: number;
+  limit?: number;
+  offset?: number;
+}
+
 export interface SpendingInsightsDto {
   summary: {
     totalSent: number;
@@ -212,6 +223,53 @@ export class ActivityService {
     });
 
     return insights;
+  }
+
+  async searchTransactions(
+    userId: string,
+    params: TransactionSearchParams,
+  ): Promise<{ items: ActivityTransactionDto[]; total: number }> {
+    const all = await this.repository.listByUserId(userId);
+    let results = all.map((r) => this.toTransactionDto(r));
+
+    const q = params.q?.trim().toLowerCase();
+    if (q) {
+      results = results.filter(
+        (t) =>
+          t.recipientName.toLowerCase().includes(q) ||
+          t.recipientPhone.toLowerCase().includes(q) ||
+          t.id.toLowerCase().includes(q),
+      );
+    }
+
+    if (params.status) {
+      results = results.filter((t) => t.status === params.status);
+    }
+
+    if (params.dateFrom) {
+      const from = new Date(params.dateFrom).getTime();
+      results = results.filter((t) => new Date(t.timestamp).getTime() >= from);
+    }
+
+    if (params.dateTo) {
+      const to = new Date(params.dateTo).getTime();
+      results = results.filter((t) => new Date(t.timestamp).getTime() <= to);
+    }
+
+    if (params.amountMin !== undefined) {
+      results = results.filter((t) => t.amount >= params.amountMin!);
+    }
+
+    if (params.amountMax !== undefined) {
+      results = results.filter((t) => t.amount <= params.amountMax!);
+    }
+
+    const total = results.length;
+    const offset = Math.max(0, params.offset ?? 0);
+    const limit = Math.min(100, Math.max(1, params.limit ?? 50));
+    const items = results.slice(offset, offset + limit);
+
+    return { items, total };
   }
 
   listNotifications(userId: string, limit = 5) {

--- a/backend/src/modules/rbac/accessGuardService.ts
+++ b/backend/src/modules/rbac/accessGuardService.ts
@@ -1,0 +1,89 @@
+import type { UserRole } from '../../auth/sessionTypes';
+import { logger } from '../../logger';
+
+/**
+ * Application-level implementation of the Access Guard contract pattern.
+ *
+ * Mirrors the on-chain contract logic (gate + per-address allowlist) so the
+ * backend can enforce the same rules without a live Soroban RPC call on every
+ * request.  Admins may sync state from the deployed contract via the admin API.
+ *
+ * Contract: CDPOR7XAJDYSPCQMLM5AJESL4IOC7L2J34GW5UKSTC6NX7Z4GG53OLEF
+ * Logic:    check(addr) = gate_open AND address_allowed
+ */
+export class AccessGuardService {
+  /** Global gate — when false every non-admin action is blocked */
+  private gateOpen = true;
+
+  /**
+   * Per-user explicit allow/block list.
+   * Absent = default open (opt-out model matching contract's unwrap_or(false)
+   * with gate defaulting open).
+   */
+  private readonly allowList = new Map<string, boolean>();
+
+  /** Role registry — absent = 'user' */
+  private readonly roles = new Map<string, UserRole>();
+
+  // ── Gate control ────────────────────────────────────────────────────────────
+
+  setGate(open: boolean, adminId: string): void {
+    logger.info({ adminId, open }, 'access-guard: gate changed');
+    this.gateOpen = open;
+  }
+
+  isGateOpen(): boolean {
+    return this.gateOpen;
+  }
+
+  // ── Per-user allow list ──────────────────────────────────────────────────────
+
+  setAllow(userId: string, allow: boolean, adminId: string): void {
+    logger.info({ adminId, userId, allow }, 'access-guard: allow changed');
+    this.allowList.set(userId, allow);
+  }
+
+  isAllowed(userId: string): boolean {
+    const explicit = this.allowList.get(userId);
+    return explicit === undefined ? true : explicit;
+  }
+
+  /**
+   * Combined check: gate_open AND address_allowed.
+   * Admins bypass the gate and per-user block.
+   */
+  check(userId: string): boolean {
+    if (this.isAdmin(userId)) return true;
+    return this.gateOpen && this.isAllowed(userId);
+  }
+
+  // ── Role management ──────────────────────────────────────────────────────────
+
+  setRole(userId: string, role: UserRole, adminId?: string): void {
+    logger.info({ adminId, userId, role }, 'access-guard: role changed');
+    this.roles.set(userId, role);
+  }
+
+  getRole(userId: string): UserRole {
+    return this.roles.get(userId) ?? 'user';
+  }
+
+  isAdmin(userId: string): boolean {
+    return this.getRole(userId) === 'admin';
+  }
+
+  // ── Introspection ─────────────────────────────────────────────────────────
+
+  getStatus() {
+    return {
+      gateOpen: this.gateOpen,
+      blockedUsers: Array.from(this.allowList.entries())
+        .filter(([, v]) => !v)
+        .map(([id]) => id),
+      adminUsers: Array.from(this.roles.entries())
+        .filter(([, r]) => r === 'admin')
+        .map(([id]) => id),
+      contractId: 'CDPOR7XAJDYSPCQMLM5AJESL4IOC7L2J34GW5UKSTC6NX7Z4GG53OLEF',
+    };
+  }
+}

--- a/backend/src/modules/transfers/__tests__/transferIntegration.test.ts
+++ b/backend/src/modules/transfers/__tests__/transferIntegration.test.ts
@@ -1,0 +1,345 @@
+/**
+ * Integration tests for the full transfer flow.
+ *
+ * These tests wire real implementations together (TransferLifecycle,
+ * WalletService, escrow store, session store) instead of mocks so we can
+ * exercise the wallet → escrow → release path end-to-end and validate
+ * balance changes throughout.
+ */
+
+import { TransferLifecycle } from '../transferLifecycle';
+import { InMemoryTransferRepository } from '../inMemoryTransferRepository';
+import { WalletService } from '../../wallets/walletService';
+import { ComplianceService } from '../../compliance/complianceService';
+import { FraudService } from '../../fraud/fraudService';
+import { EventBus } from '../../../core/eventBus';
+import { CreateTransferCommand, TransferStatusEntry } from '../domain';
+import {
+  createMariaSession,
+  getSessionUserBalance,
+  adjustSessionUserBalance,
+} from '../../../auth/sessionStore';
+
+// ── helpers ─────────────────────────────────────────────────────────────────
+
+function buildLifecycle(overrides?: {
+  wallets?: Partial<WalletService>;
+  compliance?: Partial<ComplianceService>;
+  fraud?: Partial<FraudService>;
+}) {
+  const repository = new InMemoryTransferRepository();
+  const wallets = new WalletService();
+  const compliance = new ComplianceService();
+  const fraud = new FraudService();
+  const eventBus = new EventBus();
+
+  if (overrides?.wallets) Object.assign(wallets, overrides.wallets);
+  if (overrides?.compliance) Object.assign(compliance, overrides.compliance);
+
+  const lifecycle = new TransferLifecycle(
+    repository,
+    wallets,
+    compliance,
+    fraud,
+    eventBus,
+  );
+
+  return { lifecycle, repository, wallets, compliance, fraud, eventBus };
+}
+
+function walletCommand(
+  overrides: Partial<CreateTransferCommand> = {},
+): CreateTransferCommand {
+  return {
+    idempotencyKey: `key-${Date.now()}-${Math.random()}`,
+    fromWalletId: 'wallet_maria_santos_123',
+    userId: '1',
+    amount: 50,
+    currency: 'USDC',
+    recipient: {
+      type: 'wallet',
+      walletPublicKey: 'GTEST123VALIDPUBLICKEY000',
+    },
+    ...overrides,
+  };
+}
+
+// ── tests ─────────────────────────────────────────────────────────────────────
+
+describe('Transfer Integration — wallet → escrow → release', () => {
+  beforeEach(() => {
+    // Reset Maria's balance to a known value before each test
+    createMariaSession();
+    // Force a clean balance
+    const current = getSessionUserBalance('1') ?? 0;
+    adjustSessionUserBalance('1', 1250.5 - current);
+  });
+
+  // ── 1. Happy path ──────────────────────────────────────────────────────────
+
+  it('deducts balance when a transfer is held in escrow', async () => {
+    const { lifecycle } = buildLifecycle();
+    const balanceBefore = getSessionUserBalance('1')!;
+
+    const transfer = await lifecycle.createTransfer(walletCommand({ amount: 100 }));
+
+    const balanceAfter = getSessionUserBalance('1')!;
+    expect(transfer.state).toBe('held');
+    expect(transfer.escrowId).toBeDefined();
+    expect(balanceAfter).toBeCloseTo(balanceBefore - 100, 2);
+  });
+
+  it('settles the transfer and records completed state', async () => {
+    const { lifecycle, repository } = buildLifecycle();
+
+    const cmd = walletCommand({ amount: 75 });
+    const transfer = await lifecycle.createTransfer(cmd);
+    expect(transfer.state).toBe('held');
+
+    // Allow the async settlement timer to fire (default delay is 0 in test env)
+    await new Promise((resolve) => setTimeout(resolve, 50));
+
+    const settled = await repository.findById(transfer.id);
+    expect(settled?.state).toBe('settled');
+    expect(settled?.statusHistory.map((h: TransferStatusEntry) => h.state)).toContain('settled');
+  });
+
+  it('preserves idempotency — same key returns same transfer', async () => {
+    const { lifecycle } = buildLifecycle();
+    const cmd = walletCommand();
+
+    const first = await lifecycle.createTransfer(cmd);
+    const second = await lifecycle.createTransfer(cmd);
+
+    expect(second.id).toBe(first.id);
+    expect(second.state).toBe(first.state);
+  });
+
+  it('records full status history: created → validated → held → settled', async () => {
+    const { lifecycle, repository } = buildLifecycle();
+    await lifecycle.createTransfer(walletCommand());
+
+    await new Promise((resolve) => setTimeout(resolve, 50));
+
+    const [transfer] = (await repository.listByUserId('1')).slice(0, 1);
+    const states = transfer.statusHistory.map((h: TransferStatusEntry) => h.state);
+
+    expect(states).toContain('created');
+    expect(states).toContain('validated');
+    expect(states).toContain('held');
+    expect(states).toContain('settled');
+  });
+
+  // ── 2. Balance validation ──────────────────────────────────────────────────
+
+  it('rejects transfer when balance is insufficient', async () => {
+    const { lifecycle } = buildLifecycle();
+    // Drain balance
+    adjustSessionUserBalance('1', -(getSessionUserBalance('1') ?? 0));
+    // Give just 10
+    adjustSessionUserBalance('1', 10);
+
+    await expect(lifecycle.createTransfer(walletCommand({ amount: 100 }))).rejects.toThrow(
+      /insufficient balance/i,
+    );
+  });
+
+  it('balance is NOT changed when transfer creation fails validation', async () => {
+    const { lifecycle } = buildLifecycle();
+    const balanceBefore = getSessionUserBalance('1')!;
+
+    await expect(
+      lifecycle.createTransfer(walletCommand({ amount: 0 })),
+    ).rejects.toThrow(/greater than zero/i);
+
+    expect(getSessionUserBalance('1')).toBeCloseTo(balanceBefore, 2);
+  });
+
+  // ── 3. Escrow lifecycle ────────────────────────────────────────────────────
+
+  it('escrow is created with correct amount and currency', async () => {
+    const { lifecycle, wallets } = buildLifecycle();
+    const transfer = await lifecycle.createTransfer(walletCommand({ amount: 200 }));
+
+    const escrow = await wallets.getEscrow(transfer.id);
+    expect(escrow).not.toBeNull();
+    expect(escrow?.amount).toBe(200);
+    expect(escrow?.currency).toBe('USDC');
+    expect(escrow?.status).toBe('held');
+  });
+
+  it('escrow transitions to released after settlement', async () => {
+    const { lifecycle, wallets } = buildLifecycle();
+    const transfer = await lifecycle.createTransfer(walletCommand({ amount: 50 }));
+
+    await new Promise((resolve) => setTimeout(resolve, 50));
+
+    const escrow = await wallets.getEscrow(transfer.id);
+    expect(escrow?.status).toBe('released');
+  });
+
+  // ── 4. Failure simulation ──────────────────────────────────────────────────
+
+  it('marks transfer as failed and refunds escrow after max settlement attempts', async () => {
+    const { lifecycle, repository } = buildLifecycle({
+      wallets: {
+        settleEscrow: jest.fn().mockRejectedValue(new Error('Network error')),
+      } as any,
+    });
+
+    const cmd = walletCommand({ amount: 30 });
+    const transfer = await lifecycle.createTransfer(cmd);
+
+    // Wait for all retry attempts (3 × settlementDelayMs, default 0 in tests)
+    await new Promise((resolve) => setTimeout(resolve, 200));
+
+    const failed = await repository.findById(transfer.id);
+    expect(failed?.state).toBe('failed');
+    expect(failed?.lastError).toMatch(/Network error/);
+    expect(failed?.statusHistory.at(-1)?.state).toBe('failed');
+  });
+
+  it('refunds balance after escrow auto-refund on failure', async () => {
+    const balanceBefore = getSessionUserBalance('1')!;
+
+    const { lifecycle } = buildLifecycle({
+      wallets: {
+        settleEscrow: jest.fn().mockRejectedValue(new Error('Settlement failed')),
+      } as any,
+    });
+
+    await lifecycle.createTransfer(walletCommand({ amount: 50 }));
+    await new Promise((resolve) => setTimeout(resolve, 200));
+
+    // Balance should be restored after refund
+    const balanceAfter = getSessionUserBalance('1')!;
+    expect(balanceAfter).toBeCloseTo(balanceBefore, 2);
+  });
+
+  it('compliance failure blocks transfer creation', async () => {
+    const { lifecycle } = buildLifecycle({
+      compliance: {
+        evaluateTransfer: jest.fn().mockResolvedValue({
+          canProceed: false,
+          blockers: ['Daily limit exceeded'],
+          warnings: [],
+          riskScore: 'high',
+          tier: {
+            id: 'starter',
+            name: 'Starter',
+            dailyLimit: 500,
+            monthlyLimit: 2000,
+            yearlyLimit: 10000,
+            singleTransactionLimit: 250,
+            description: 'Starter',
+            requirements: [],
+            benefits: [],
+          },
+        }),
+      } as any,
+    });
+
+    await expect(lifecycle.createTransfer(walletCommand({ amount: 10 }))).rejects.toThrow(
+      /Compliance requirements not satisfied/,
+    );
+  });
+
+  // ── 5. Event publication ───────────────────────────────────────────────────
+
+  it('publishes transfer.created event with correct payload', async () => {
+    const repository = new InMemoryTransferRepository();
+    const wallets = new WalletService();
+    const compliance = new ComplianceService();
+    const fraud = new FraudService();
+    const eventBus = new EventBus();
+    const publishSpy = jest.spyOn(eventBus, 'publish');
+
+    const lifecycle = new TransferLifecycle(repository, wallets, compliance, fraud, eventBus);
+    const cmd = walletCommand({ amount: 60 });
+    await lifecycle.createTransfer(cmd);
+
+    const createdEvent = publishSpy.mock.calls.find(
+      ([e]) => (e as any).type === 'transfer.created',
+    );
+    expect(createdEvent).toBeDefined();
+    expect((createdEvent![0] as any).payload.userId).toBe('1');
+    expect((createdEvent![0] as any).payload.amount).toBe(60);
+  });
+
+  it('publishes transfer.settled event after successful settlement', async () => {
+    const repository = new InMemoryTransferRepository();
+    const wallets = new WalletService();
+    const compliance = new ComplianceService();
+    const fraud = new FraudService();
+    const eventBus = new EventBus();
+    const publishSpy = jest.spyOn(eventBus, 'publish');
+
+    const lifecycle = new TransferLifecycle(repository, wallets, compliance, fraud, eventBus);
+    await lifecycle.createTransfer(walletCommand({ amount: 40 }));
+    await new Promise((resolve) => setTimeout(resolve, 50));
+
+    const settledEvent = publishSpy.mock.calls.find(
+      ([e]) => (e as any).type === 'transfer.settled',
+    );
+    expect(settledEvent).toBeDefined();
+    expect((settledEvent![0] as any).payload.amount).toBe(40);
+  });
+
+  it('publishes transfer.failed event on exhausted retries', async () => {
+    const repository = new InMemoryTransferRepository();
+    const wallets = new WalletService();
+    const compliance = new ComplianceService();
+    const fraud = new FraudService();
+    const eventBus = new EventBus();
+    const publishSpy = jest.spyOn(eventBus, 'publish');
+
+    jest.spyOn(wallets, 'settleEscrow').mockRejectedValue(new Error('timeout'));
+
+    const lifecycle = new TransferLifecycle(repository, wallets, compliance, fraud, eventBus);
+    await lifecycle.createTransfer(walletCommand({ amount: 25 }));
+    await new Promise((resolve) => setTimeout(resolve, 200));
+
+    const failedEvent = publishSpy.mock.calls.find(
+      ([e]) => (e as any).type === 'transfer.failed',
+    );
+    expect(failedEvent).toBeDefined();
+    expect((failedEvent![0] as any).payload.error).toMatch(/timeout/);
+  });
+
+  // ── 6. Recipient types ──────────────────────────────────────────────────────
+
+  it('accepts cash_pickup recipient and settles to partner account', async () => {
+    const { lifecycle, repository } = buildLifecycle();
+    const cmd = walletCommand({
+      recipient: {
+        type: 'cash_pickup',
+        partnerCode: 'MONEYGRAM',
+        country: 'MX',
+      },
+    });
+
+    await lifecycle.createTransfer(cmd);
+    await new Promise((resolve) => setTimeout(resolve, 50));
+
+    const [transfer] = await repository.listByUserId('1');
+    expect(transfer.state).toBe('settled');
+    expect(transfer.recipient.type).toBe('cash_pickup');
+  });
+
+  it('accepts bank recipient and settles successfully', async () => {
+    const { lifecycle, repository } = buildLifecycle();
+    const cmd = walletCommand({
+      recipient: {
+        type: 'bank',
+        partnerCode: 'WISE',
+        country: 'UK',
+      },
+    });
+
+    await lifecycle.createTransfer(cmd);
+    await new Promise((resolve) => setTimeout(resolve, 50));
+
+    const [transfer] = await repository.listByUserId('1');
+    expect(transfer.state).toBe('settled');
+  });
+});

--- a/backend/src/routes/activity.ts
+++ b/backend/src/routes/activity.ts
@@ -1,10 +1,23 @@
 import type { FastifyInstance, FastifyReply } from 'fastify';
 import { getSession } from '../auth/sessionStore';
-import type { JwtSessionPayload, Session } from '../auth/sessionTypes';
+import type { JwtSessionPayload, PublicUser, Session } from '../auth/sessionTypes';
+
+type VerifiedSession = Session & { user: PublicUser };
 import { requireVerifiedSession } from '../middleware/authenticate';
 
 interface ActivityQuery {
   limit?: string;
+}
+
+interface SearchQuery {
+  q?: string;
+  status?: string;
+  dateFrom?: string;
+  dateTo?: string;
+  amountMin?: string;
+  amountMax?: string;
+  limit?: string;
+  offset?: string;
 }
 
 export default async function activityRoutes(fastify: FastifyInstance) {
@@ -19,6 +32,37 @@ export default async function activityRoutes(fastify: FastifyInstance) {
       return {
         items: await fastify.container.services.activity.listTransactions(session.user.id, limit),
       };
+    },
+  );
+
+  fastify.get<{ Querystring: SearchQuery }>(
+    '/activity/transactions/search',
+    { preHandler: [requireVerifiedSession] },
+    async (req, reply) => {
+      const session = requireSessionUser(req.user as JwtSessionPayload, reply);
+      if (!session) return;
+
+      const q = req.query ?? {};
+      const status = ['pending', 'completed', 'failed'].includes(q.status ?? '')
+        ? (q.status as 'pending' | 'completed' | 'failed')
+        : undefined;
+
+      const result = await fastify.container.services.activity.searchTransactions(
+        session.user!.id,
+        {
+          q: q.q,
+          status,
+          dateFrom: q.dateFrom,
+          dateTo: q.dateTo,
+          amountMin: q.amountMin !== undefined ? parseFloat(q.amountMin) : undefined,
+          amountMax: q.amountMax !== undefined ? parseFloat(q.amountMax) : undefined,
+          limit: sanitizeLimit(q.limit, 50, 100),
+          offset: q.offset !== undefined ? Math.max(0, parseInt(q.offset, 10) || 0) : 0,
+        },
+      );
+
+      reply.header('Cache-Control', 'no-store');
+      return result;
     },
   );
 
@@ -65,7 +109,7 @@ export default async function activityRoutes(fastify: FastifyInstance) {
   );
 }
 
-function requireSessionUser(token: JwtSessionPayload, reply: FastifyReply): Session | null {
+function requireSessionUser(token: JwtSessionPayload, reply: FastifyReply): VerifiedSession | null {
   const session = getSession(token.sub);
   if (!session) {
     reply.code(401).send({ error: 'Session expired' });
@@ -75,7 +119,7 @@ function requireSessionUser(token: JwtSessionPayload, reply: FastifyReply): Sess
     reply.code(400).send({ error: 'Onboarding incomplete' });
     return null;
   }
-  return session;
+  return session as VerifiedSession;
 }
 
 function sanitizeLimit(value: string | undefined, fallback: number, maximum: number) {

--- a/backend/src/routes/admin.ts
+++ b/backend/src/routes/admin.ts
@@ -1,0 +1,80 @@
+import type { FastifyInstance } from 'fastify';
+import { requireVerifiedSession } from '../middleware/authenticate';
+import { requireRole } from '../middleware/requireRole';
+import { getSession, saveSession } from '../auth/sessionStore';
+import type { JwtSessionPayload } from '../auth/sessionTypes';
+
+interface SetGateBody {
+  open: boolean;
+}
+
+interface SetAllowBody {
+  userId: string;
+  allow: boolean;
+}
+
+interface SetRoleBody {
+  userId: string;
+  role: 'admin' | 'user';
+}
+
+export default async function adminRoutes(fastify: FastifyInstance) {
+  const adminGuards = { preHandler: [requireVerifiedSession, requireRole('admin')] };
+
+  /** GET /admin/rbac/status — view current Access Guard state */
+  fastify.get('/admin/rbac/status', adminGuards, async (req) => {
+    return fastify.container.services.accessGuard.getStatus();
+  });
+
+  /** POST /admin/rbac/gate — open or close the system-wide transfer gate */
+  fastify.post<{ Body: SetGateBody }>(
+    '/admin/rbac/gate',
+    adminGuards,
+    async (req, reply) => {
+      if (typeof req.body?.open !== 'boolean') {
+        return reply.code(400).send({ error: '`open` (boolean) is required' });
+      }
+      const payload = req.user as JwtSessionPayload;
+      fastify.container.services.accessGuard.setGate(req.body.open, payload.sub);
+      return { gateOpen: req.body.open };
+    },
+  );
+
+  /** POST /admin/rbac/allow — explicitly allow or block a user */
+  fastify.post<{ Body: SetAllowBody }>(
+    '/admin/rbac/allow',
+    adminGuards,
+    async (req, reply) => {
+      const { userId, allow } = req.body ?? {};
+      if (!userId || typeof allow !== 'boolean') {
+        return reply.code(400).send({ error: '`userId` and `allow` (boolean) are required' });
+      }
+      const payload = req.user as JwtSessionPayload;
+      fastify.container.services.accessGuard.setAllow(userId, allow, payload.sub);
+      return { userId, allow };
+    },
+  );
+
+  /** POST /admin/rbac/role — assign a role to a user */
+  fastify.post<{ Body: SetRoleBody }>(
+    '/admin/rbac/role',
+    adminGuards,
+    async (req, reply) => {
+      const { userId, role } = req.body ?? {};
+      if (!userId || !['admin', 'user'].includes(role)) {
+        return reply.code(400).send({ error: '`userId` and `role` (admin|user) are required' });
+      }
+      const payload = req.user as JwtSessionPayload;
+      fastify.container.services.accessGuard.setRole(userId, role, payload.sub);
+
+      // Persist role into the session so it's reflected immediately
+      const session = getSession(userId);
+      if (session) {
+        session.role = role;
+        saveSession(session);
+      }
+
+      return { userId, role };
+    },
+  );
+}

--- a/backend/src/routes/transfers.ts
+++ b/backend/src/routes/transfers.ts
@@ -5,6 +5,7 @@ import type { JwtSessionPayload, Session } from '../auth/sessionTypes';
 import { CreateTransferCommand, TransferRecord } from '../modules/transfers/domain';
 import { canonicalizeSignedTransferPayload, verifySignedTransferPayload } from '../modules/transfers/requestSigning';
 import { requireVerifiedSession } from '../middleware/authenticate';
+import { requireAccessGuard } from '../middleware/requireRole';
 
 interface TransferRequest {
   idempotency_key: string;
@@ -25,7 +26,7 @@ interface TransferRequest {
 }
 
 export default async function transferRoutes(fastify: FastifyInstance) {
-  fastify.post('/transfers', { preHandler: [requireVerifiedSession] }, async (req, reply) => {
+  fastify.post('/transfers', { preHandler: [requireVerifiedSession, requireAccessGuard] }, async (req, reply) => {
     const body = req.body as TransferRequest;
     try {
       const payload = requestPayloadForSigning(body);

--- a/backend/src/test/setup.ts
+++ b/backend/src/test/setup.ts
@@ -1,6 +1,7 @@
 // Test setup for backend
 process.env.NODE_ENV = 'test';
 process.env.JWT_SECRET = 'test-jwt-secret';
+process.env.WORKER_DELAY_MS = '0';  // fire settlement immediately in tests
 process.env.STELLAR_NETWORK = 'TESTNET';
 process.env.STELLAR_HORIZON_URL = 'https://horizon-testnet.stellar.org';
 process.env.STELLAR_DISTRIBUTION_SECRET = 'STEST123456789ABCDEF';

--- a/jest.config.js
+++ b/jest.config.js
@@ -3,7 +3,7 @@ export default {
   preset: 'ts-jest',
   testEnvironment: 'jsdom',
   setupFilesAfterEnv: ['<rootDir>/src/test/setup.ts'],
-  moduleNameMapping: {
+  moduleNameMapper: {
     '^@/(.*)$': '<rootDir>/src/$1',
   },
   transform: {

--- a/src/components/FeeDisplay.tsx
+++ b/src/components/FeeDisplay.tsx
@@ -4,9 +4,15 @@
  */
 
 import React from "react";
-import { Info, Star, Shield, ArrowRight } from "lucide-react";
+import { Info, Shield, ArrowRight, Zap, HelpCircle } from "lucide-react";
 import { cn } from "@/lib/utils";
 import { FeeCalculationResult } from "@/lib/feeCalculator";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+} from "@/components/ui/tooltip";
 
 interface FeeDisplayProps {
   fees: FeeCalculationResult;
@@ -15,19 +21,44 @@ interface FeeDisplayProps {
   className?: string;
 }
 
+function FeeTooltip({ content }: { content: string }) {
+  return (
+    <TooltipProvider delayDuration={200}>
+      <Tooltip>
+        <TooltipTrigger asChild>
+          <HelpCircle className="w-3.5 h-3.5 text-muted-foreground/60 cursor-help hover:text-muted-foreground transition-colors" />
+        </TooltipTrigger>
+        <TooltipContent className="max-w-[220px] text-xs leading-relaxed">
+          {content}
+        </TooltipContent>
+      </Tooltip>
+    </TooltipProvider>
+  );
+}
+
 /**
- * Compact fee display (single line)
+ * Compact fee display (single line) — shows total with effective rate
  */
 export function CompactFeeDisplay({
   fees,
   className,
 }: Omit<FeeDisplayProps, "variant">) {
+  const effectiveRate = fees.amount > 0
+    ? ((fees.totalFee / fees.amount) * 100).toFixed(2)
+    : "0.00";
+
   return (
     <div className={cn("flex items-center justify-between text-sm", className)}>
-      <span className="text-muted-foreground">Total fees</span>
-      <span className="font-semibold text-foreground">
-        ${fees.totalFee.toFixed(2)}
-      </span>
+      <div className="flex items-center gap-1.5 text-muted-foreground">
+        <span>Total fees</span>
+        <FeeTooltip content="Combined Stellar network fee + SwiftSend service fee. Both are deducted from your send amount." />
+      </div>
+      <div className="flex items-center gap-1.5">
+        <span className="text-xs text-muted-foreground">({effectiveRate}%)</span>
+        <span className="font-semibold text-foreground">
+          ${fees.totalFee.toFixed(2)}
+        </span>
+      </div>
     </div>
   );
 }
@@ -47,47 +78,69 @@ export function MinimalFeeDisplay({
 }
 
 /**
- * Detailed fee display with breakdown
+ * Detailed fee display with full breakdown, tooltips, and savings comparison
  */
 export function DetailedFeeDisplay({
   fees,
   showSavings = false,
   className,
 }: Omit<FeeDisplayProps, "variant">) {
-  const traditionalFee = fees.amount * 0.02; // 2% traditional fee
+  const traditionalFee = fees.amount * 0.02;
   const savings = traditionalFee - fees.totalFee;
+  const networkFeePercent = fees.amount > 0
+    ? ((fees.networkFee / fees.amount) * 100).toFixed(4)
+    : "0.0000";
+  const effectiveTotalRate = fees.amount > 0
+    ? ((fees.totalFee / fees.amount) * 100).toFixed(2)
+    : "0.00";
 
   return (
     <div className={cn("space-y-3", className)}>
-      {/* Network Fee */}
+      {/* Network Fee row */}
       <div className="flex justify-between items-center text-sm">
         <div className="flex items-center gap-2 text-muted-foreground">
-          <Star className="w-4 h-4 text-blue-500" />
+          <Zap className="w-4 h-4 text-blue-500 shrink-0" />
           <span>Stellar network fee</span>
+          <FeeTooltip content="A tiny fixed fee paid to Stellar validators to process your transaction on the blockchain. Currently ~0.00001 XLM, converted to USD. This goes to the network, not SwiftSend." />
         </div>
-        <span className="font-medium text-foreground">
-          ${fees.networkFee.toFixed(4)}
-        </span>
+        <div className="flex items-center gap-1.5 text-right">
+          <span className="text-xs text-muted-foreground">({networkFeePercent}%)</span>
+          <span className="font-medium text-foreground tabular-nums">
+            ${fees.networkFee.toFixed(4)}
+          </span>
+        </div>
       </div>
 
-      {/* Service Fee */}
+      {/* Service Fee row */}
       <div className="flex justify-between items-center text-sm">
         <div className="flex items-center gap-2 text-muted-foreground">
-          <Shield className="w-4 h-4 text-green-500" />
-          <span>Service fee ({fees.feePercentage.toFixed(2)}%)</span>
+          <Shield className="w-4 h-4 text-green-500 shrink-0" />
+          <span>SwiftSend service fee</span>
+          <FeeTooltip content="SwiftSend's fee for compliance monitoring, fraud detection, escrow management, and 24/7 customer support. Calculated as a percentage of your send amount, subject to a minimum and maximum cap." />
         </div>
-        <span className="font-medium text-foreground">
-          ${fees.serviceFee.toFixed(2)}
-        </span>
+        <div className="flex items-center gap-1.5 text-right">
+          <span className="text-xs text-muted-foreground">
+            ({fees.feePercentage.toFixed(2)}%)
+          </span>
+          <span className="font-medium text-foreground tabular-nums">
+            ${fees.serviceFee.toFixed(2)}
+          </span>
+        </div>
       </div>
 
       {/* Total Fee */}
       <div className="border-t border-border/50 pt-3">
         <div className="flex justify-between items-center text-sm">
-          <span className="text-muted-foreground">Total fees</span>
-          <span className="font-semibold text-foreground">
-            ${fees.totalFee.toFixed(2)}
-          </span>
+          <div className="flex items-center gap-1.5 text-muted-foreground">
+            <span>Total fees</span>
+            <FeeTooltip content={`Effective rate: ${effectiveTotalRate}% of your send amount. This includes both the Stellar network fee and SwiftSend's service fee.`} />
+          </div>
+          <div className="flex items-center gap-1.5">
+            <span className="text-xs text-muted-foreground">({effectiveTotalRate}%)</span>
+            <span className="font-semibold text-foreground tabular-nums">
+              ${fees.totalFee.toFixed(2)}
+            </span>
+          </div>
         </div>
       </div>
 
@@ -95,31 +148,44 @@ export function DetailedFeeDisplay({
       <div className="bg-gradient-to-r from-green-50 to-green-50/50 dark:from-green-900/20 dark:to-green-900/10 rounded-lg p-3 border border-green-200/50 dark:border-green-800/50">
         <div className="flex items-center justify-between">
           <div className="flex items-center gap-2">
-            <ArrowRight className="w-4 h-4 text-green-600" />
-            <span className="text-sm font-semibold text-foreground">
-              Recipient receives
-            </span>
+            <ArrowRight className="w-4 h-4 text-green-600 shrink-0" />
+            <div>
+              <span className="text-sm font-semibold text-foreground">
+                Recipient receives
+              </span>
+              <p className="text-xs text-muted-foreground">
+                After all fees · arrives in ~5 seconds
+              </p>
+            </div>
           </div>
-          <span className="text-lg font-bold text-green-600">
+          <span className="text-lg font-bold text-green-600 tabular-nums">
             ${fees.recipientGets.toFixed(2)}
           </span>
         </div>
       </div>
 
       {/* Savings Comparison */}
-      {showSavings && (
+      {showSavings && savings > 0 && (
         <div className="bg-blue-50 dark:bg-blue-900/20 rounded-lg p-3 border border-blue-200/50 dark:border-blue-800/50">
           <div className="flex items-center gap-2 mb-2">
-            <Info className="w-4 h-4 text-blue-600" />
+            <Info className="w-4 h-4 text-blue-600 shrink-0" />
             <span className="text-sm font-medium text-blue-900 dark:text-blue-100">
-              Savings vs traditional wire
+              vs. traditional bank wire
             </span>
           </div>
-          <div className="text-sm text-blue-700 dark:text-blue-300">
-            <p>Traditional fee: ${traditionalFee.toFixed(2)} (2%)</p>
-            <p className="font-semibold text-green-600 dark:text-green-400">
-              You save: ${savings.toFixed(2)}
-            </p>
+          <div className="grid grid-cols-2 gap-2 text-xs">
+            <div>
+              <p className="text-muted-foreground">Bank wire fee (≈2%)</p>
+              <p className="font-semibold text-foreground">${traditionalFee.toFixed(2)}</p>
+            </div>
+            <div>
+              <p className="text-muted-foreground">SwiftSend fee ({effectiveTotalRate}%)</p>
+              <p className="font-semibold text-green-600">${fees.totalFee.toFixed(2)}</p>
+            </div>
+          </div>
+          <div className="mt-2 pt-2 border-t border-blue-200/50 dark:border-blue-800/50 flex justify-between text-xs">
+            <span className="text-blue-700 dark:text-blue-300 font-medium">You save</span>
+            <span className="font-bold text-green-600">${savings.toFixed(2)}</span>
           </div>
         </div>
       )}
@@ -167,7 +233,12 @@ export function FeeComparisonCard({
 }) {
   const traditionalFee = amount * 0.02;
   const savings = traditionalFee - fees.totalFee;
-  const savingsPercentage = (savings / traditionalFee) * 100;
+  const savingsPercentage = traditionalFee > 0
+    ? (savings / traditionalFee) * 100
+    : 0;
+  const effectiveRate = amount > 0
+    ? ((fees.totalFee / amount) * 100).toFixed(2)
+    : "0.00";
 
   return (
     <div
@@ -179,25 +250,25 @@ export function FeeComparisonCard({
       <div className="grid grid-cols-2 gap-4">
         {/* Traditional */}
         <div>
-          <p className="text-xs text-muted-foreground font-medium mb-2">
-            Traditional Wire
+          <p className="text-xs text-muted-foreground font-medium mb-1">
+            Traditional wire
           </p>
           <p className="text-lg font-bold text-foreground">
             ${traditionalFee.toFixed(2)}
           </p>
-          <p className="text-xs text-muted-foreground">2% fee • 1-3 days</p>
+          <p className="text-xs text-muted-foreground">2.00% · 1–3 business days</p>
         </div>
 
         {/* SwiftSend */}
         <div>
-          <p className="text-xs text-muted-foreground font-medium mb-2">
+          <p className="text-xs text-muted-foreground font-medium mb-1">
             SwiftSend
           </p>
           <p className="text-lg font-bold text-green-600">
             ${fees.totalFee.toFixed(2)}
           </p>
           <p className="text-xs text-muted-foreground">
-            {fees.feePercentage.toFixed(2)}% fee • 3-5 seconds
+            {effectiveRate}% · ~5 seconds
           </p>
         </div>
       </div>
@@ -205,7 +276,10 @@ export function FeeComparisonCard({
       {/* Savings */}
       <div className="mt-4 pt-4 border-t border-border/50">
         <div className="flex items-center justify-between">
-          <span className="text-sm font-medium text-foreground">You save</span>
+          <div className="flex items-center gap-1.5">
+            <span className="text-sm font-medium text-foreground">You save</span>
+            <FeeTooltip content="Compared to a typical 2% international wire transfer fee at a traditional bank." />
+          </div>
           <div className="text-right">
             <p className="text-lg font-bold text-green-600">
               ${savings.toFixed(2)}

--- a/src/lib/activity.ts
+++ b/src/lib/activity.ts
@@ -96,6 +96,46 @@ export async function fetchTransactions(limit = 50): Promise<Transaction[]> {
   return body.items.map(parseTransactionDto);
 }
 
+export interface TransactionSearchParams {
+  q?: string;
+  status?: 'pending' | 'completed' | 'failed';
+  dateFrom?: Date;
+  dateTo?: Date;
+  amountMin?: number;
+  amountMax?: number;
+  limit?: number;
+  offset?: number;
+}
+
+export interface TransactionSearchResult {
+  items: Transaction[];
+  total: number;
+}
+
+export async function searchTransactions(
+  params: TransactionSearchParams,
+): Promise<TransactionSearchResult> {
+  const qs = new URLSearchParams();
+  if (params.q) qs.set('q', params.q);
+  if (params.status) qs.set('status', params.status);
+  if (params.dateFrom) qs.set('dateFrom', params.dateFrom.toISOString());
+  if (params.dateTo) qs.set('dateTo', params.dateTo.toISOString());
+  if (params.amountMin !== undefined) qs.set('amountMin', String(params.amountMin));
+  if (params.amountMax !== undefined) qs.set('amountMax', String(params.amountMax));
+  if (params.limit !== undefined) qs.set('limit', String(params.limit));
+  if (params.offset !== undefined) qs.set('offset', String(params.offset));
+
+  const response = await apiFetch(`/activity/transactions/search?${qs}`);
+  const body = await requireJson<{ items: TransactionsResponseDto['items']; total: number }>(
+    response,
+    'Could not search transactions',
+  );
+  return {
+    items: body.items.map(parseTransactionDto),
+    total: body.total,
+  };
+}
+
 export async function fetchSpendingInsights(): Promise<SpendingInsights> {
   const response = await apiFetch('/activity/spending-insights');
   const body = await requireJson<SpendingInsightsDto>(response, 'Could not load spending insights');


### PR DESCRIPTION
…n tests

Closes #19 
Closes #24 
Closes #30 
Closes #32

Issue #19 — RBAC using Access Guard contract
- Add UserRole type (admin|user) to Session and JwtSessionPayload
- Implement AccessGuardService mirroring on-chain gate+allowlist pattern (contract: CDPOR7XAJDYSPCQMLM5AJESL4IOC7L2J34GW5UKSTC6NX7Z4GG53OLEF)
- Add requireRole() middleware factory and requireAccessGuard middleware
- Register AccessGuardService in the DI container
- Add /admin/rbac/* routes (gate, allow, role) gated behind requireRole('admin')
- Apply requireAccessGuard to POST /transfers (sensitive action restriction)
- Seed demo Maria session with role: 'admin'

Issue #24 — Fee breakdown transparency
- Rewrite FeeDisplay with Radix UI Tooltip on every fee row
- Show both percentage and absolute value for network fee, service fee, total
- Add descriptive tooltip text explaining what each fee covers
- Show "arrives in ~5 seconds" context in Recipient receives row
- CompactFeeDisplay now shows effective rate alongside dollar amount

Issue #30 — Transaction search
- Add TransactionSearchParams interface and searchTransactions() to ActivityService (filters: q, status, dateFrom, dateTo, amountMin, amountMax, limit, offset)
- Add GET /activity/transactions/search route with no-cache header
- Add searchTransactions() + TransactionSearchResult to frontend activity lib
- Fix activity.ts requireSessionUser return type to VerifiedSession eliminating TS18048 false positives on session.user access

Issue #32 — Transfer integration tests
- Add transferIntegration.test.ts with 14 tests covering: wallet→escrow→release happy path, idempotency, status history, balance deduction/restoration, escrow state transitions, compliance failures, settlement failures with auto-refund, event publication (created/settled/failed), and all recipient types
- Set WORKER_DELAY_MS=0 in test setup so settlement fires immediately

Also fix frontend jest.config.js: moduleNameMapping → moduleNameMapper (typo was silently breaking path-alias resolution in all frontend test suites)