### PR TITLE
Feat/implement api caching layer

### DIFF
--- a/backend/README.md
+++ b/backend/README.md
@@ -23,6 +23,7 @@ This prototype exposes:
 
 Notes:
 - This is a local prototype with in-memory stores for demo and testing the frontend integration. Replace with Postgres, real ledger and KMS in production.
+- Sensitive user fields are encrypted in-memory before storage using AES-256-GCM. In production, set `DATA_ENCRYPTION_KEY` and replace the in-memory session store with a persistent, key-managed repository.
 
 Project structure (prototype)
 - `src/app.ts` - builds Fastify app and registers routes/plugins

--- a/backend/README.md
+++ b/backend/README.md
@@ -23,6 +23,7 @@ This prototype exposes:
 
 Notes:
 - This is a local prototype with in-memory stores for demo and testing the frontend integration. Replace with Postgres, real ledger and KMS in production.
+- API-level caching is supported via Redis for repeated balance and activity history requests when `REDIS_URL` is configured.
 - Sensitive user fields are encrypted in-memory before storage using AES-256-GCM. In production, set `DATA_ENCRYPTION_KEY` and replace the in-memory session store with a persistent, key-managed repository.
 
 Project structure (prototype)

--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -16,6 +16,7 @@
         "exceljs": "^4.4.0",
         "fastify": "^4.22.0",
         "pino": "^9.1.0",
+        "redis": "^5.12.1",
         "uuid": "^9.0.0"
       },
       "devDependencies": {
@@ -1156,6 +1157,78 @@
       "resolved": "https://registry.npmjs.org/@pinojs/redact/-/redact-0.4.0.tgz",
       "integrity": "sha512-k2ENnmBugE/rzQfEcdWHcCY+/FM3VLzH9cYEsbdsoqrvzAKRhUZeRNhAZvB8OitQJ1TBed3yqWtdjzS6wJKBwg==",
       "license": "MIT"
+    },
+    "node_modules/@redis/bloom": {
+      "version": "5.12.1",
+      "resolved": "https://registry.npmjs.org/@redis/bloom/-/bloom-5.12.1.tgz",
+      "integrity": "sha512-PUUfv+ms7jgPSBVoo/DN4AkPHj4D5TZSd6SbJX7egzBplkYUcKmHRE8RKia7UtZ8bSQbLguLvxVO+asKtQfZWA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 18.19.0"
+      },
+      "peerDependencies": {
+        "@redis/client": "^5.12.1"
+      }
+    },
+    "node_modules/@redis/client": {
+      "version": "5.12.1",
+      "resolved": "https://registry.npmjs.org/@redis/client/-/client-5.12.1.tgz",
+      "integrity": "sha512-7aPGWeqA3uFm43o19umzdl16CEjK/JQGtSXVPevplTaOU3VJA/rseBC1QvYUz9lLDIMBimc4SW/zrW4S89BaCA==",
+      "license": "MIT",
+      "dependencies": {
+        "cluster-key-slot": "1.1.2"
+      },
+      "engines": {
+        "node": ">= 18.19.0"
+      },
+      "peerDependencies": {
+        "@node-rs/xxhash": "^1.1.0",
+        "@opentelemetry/api": ">=1 <2"
+      },
+      "peerDependenciesMeta": {
+        "@node-rs/xxhash": {
+          "optional": true
+        },
+        "@opentelemetry/api": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@redis/json": {
+      "version": "5.12.1",
+      "resolved": "https://registry.npmjs.org/@redis/json/-/json-5.12.1.tgz",
+      "integrity": "sha512-eOze75esLve4vfqDel7aMX08CNaiLLQS2fV8mpRN9NxPe1rVR4vQyYiW/OgtGUysF6QOr9ANhfxABKNOJfXdKg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 18.19.0"
+      },
+      "peerDependencies": {
+        "@redis/client": "^5.12.1"
+      }
+    },
+    "node_modules/@redis/search": {
+      "version": "5.12.1",
+      "resolved": "https://registry.npmjs.org/@redis/search/-/search-5.12.1.tgz",
+      "integrity": "sha512-ItlxbxC9cKI6IU1TLWoczwJCRb6TdmkEpWv05UrPawqaAnWGRu3rcIqsc5vN483T2fSociuyV1UkWIL5I4//2w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 18.19.0"
+      },
+      "peerDependencies": {
+        "@redis/client": "^5.12.1"
+      }
+    },
+    "node_modules/@redis/time-series": {
+      "version": "5.12.1",
+      "resolved": "https://registry.npmjs.org/@redis/time-series/-/time-series-5.12.1.tgz",
+      "integrity": "sha512-c6JL6E3EcZJuNqKFz+KM+l9l5mpcQiKvTwgA3blt5glWJ8hjDk0yeHN3beE/MpqYIQ8UEX44ItQzgkE/gCBELQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 18.19.0"
+      },
+      "peerDependencies": {
+        "@redis/client": "^5.12.1"
+      }
     },
     "node_modules/@sinclair/typebox": {
       "version": "0.27.10",
@@ -2380,6 +2453,15 @@
       },
       "engines": {
         "node": ">=12"
+      }
+    },
+    "node_modules/cluster-key-slot": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/cluster-key-slot/-/cluster-key-slot-1.1.2.tgz",
+      "integrity": "sha512-RMr0FhtfXemyinomL4hrWcYJxmX6deFdCxpJzhDttxgO1+bcCnkk+9drydLVDmAMG7NE6aN/fl4F7ucU/90gAA==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/co": {
@@ -5767,6 +5849,22 @@
       "license": "MIT",
       "engines": {
         "node": ">= 12.13.0"
+      }
+    },
+    "node_modules/redis": {
+      "version": "5.12.1",
+      "resolved": "https://registry.npmjs.org/redis/-/redis-5.12.1.tgz",
+      "integrity": "sha512-LDsoVvb/CpoV9EN3FXvgvSHNJWuCIzl9MiO3ppOevuGLpSGJhwfQjpEwfFJcQvNSddHADDdZaWx0HnmMxRXG7g==",
+      "license": "MIT",
+      "dependencies": {
+        "@redis/bloom": "5.12.1",
+        "@redis/client": "5.12.1",
+        "@redis/json": "5.12.1",
+        "@redis/search": "5.12.1",
+        "@redis/time-series": "5.12.1"
+      },
+      "engines": {
+        "node": ">= 18.19.0"
       }
     },
     "node_modules/require-directory": {

--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -63,7 +63,6 @@
       "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
         "@babel/generator": "^7.29.0",
@@ -1372,7 +1371,6 @@
       "integrity": "sha512-N2clP5pJhB2YnZJ3PIHFk5RkygRX5WO/5f0WC08tp0wd+sv0rsJk3MqWn3CbNmT2J505a5336jaQj4ph1AdMug==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "undici-types": "~6.21.0"
       }
@@ -2100,7 +2098,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.10.12",
         "caniuse-lite": "^1.0.30001782",
@@ -4067,7 +4064,6 @@
       "integrity": "sha512-NIy3oAFp9shda19hy4HK0HRTWKtPJmGdnvywu01nOqNC2vZg+Z+fvJDxpMQA88eb2I9EcafcdjYgsDthnYTvGw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@jest/core": "^29.7.0",
         "@jest/types": "^29.6.3",
@@ -6563,7 +6559,6 @@
       "integrity": "sha512-f0FFpIdcHgn8zcPSbf1dRevwt047YMnaiJM3u2w2RewrB+fob/zePZcrOyQoLMMO7aBIddLcQIEK5dYjkLnGrQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@cspotcode/source-map-support": "^0.8.0",
         "@tsconfig/node10": "^1.0.7",
@@ -6693,7 +6688,6 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"

--- a/backend/package.json
+++ b/backend/package.json
@@ -19,6 +19,7 @@
     "exceljs": "^4.4.0",
     "fastify": "^4.22.0",
     "pino": "^9.1.0",
+    "redis": "^5.12.1",
     "uuid": "^9.0.0"
   },
   "devDependencies": {

--- a/backend/src/app.ts
+++ b/backend/src/app.ts
@@ -15,10 +15,12 @@ import { config } from './config';
 import { logger } from './logger';
 import { createContainer } from './container';
 import { AppError } from './errors';
+import { initRedisClient, closeRedisClient } from './utils/redisCache';
 
 export async function buildApp() {
   const app = Fastify({ logger });
   const container = createContainer();
+  await initRedisClient();
 
   app.decorate('container', container);
 
@@ -77,6 +79,7 @@ export async function buildApp() {
 
   app.addHook('onClose', async () => {
     logger.info('Server shutting down');
+    await closeRedisClient();
   });
 
   return app;

--- a/backend/src/auth/__tests__/sessionStore.test.ts
+++ b/backend/src/auth/__tests__/sessionStore.test.ts
@@ -1,0 +1,32 @@
+import { createNewUserSession, getSession, saveSession } from '../sessionStore';
+import { decryptString, encryptString } from '../../utils/encryption';
+
+describe('PII encryption for session data', () => {
+  it('should encrypt and decrypt strings using AES-256-GCM', () => {
+    const value = 'alice@example.com';
+    const encrypted = encryptString(value);
+    expect(encrypted).not.toEqual(value);
+    const decrypted = decryptString(encrypted);
+    expect(decrypted).toBe(value);
+  });
+
+  it('should return decrypted session email and phone after save/get', () => {
+    const email = 'test.user@example.com';
+    const phone = '+15551234567';
+    const session = createNewUserSession(email, undefined);
+    expect(session.email).toBe(email);
+
+    const saved = getSession(session.id);
+    expect(saved).toBeDefined();
+    expect(saved?.email).toBe(email);
+    expect(saved?.phone).toBeUndefined();
+
+    saved!.phone = phone;
+    saveSession(saved!);
+
+    const updated = getSession(session.id);
+    expect(updated).toBeDefined();
+    expect(updated?.phone).toBe(phone);
+    expect(updated?.email).toBe(email);
+  });
+});

--- a/backend/src/auth/sessionStore.ts
+++ b/backend/src/auth/sessionStore.ts
@@ -1,4 +1,5 @@
 import { config } from '../config';
+import { decryptString, encryptString, transformEncryptedFields } from '../utils/encryption';
 import type { PublicUser, Session, SessionInfo } from './sessionTypes';
 
 const sessions = new Map<string, Session>();
@@ -37,6 +38,32 @@ export function buildMariaUser(): PublicUser {
   };
 }
 
+function encryptPublicUser(user: PublicUser): PublicUser {
+  return transformEncryptedFields(user, ['name', 'email', 'phone'], encryptString);
+}
+
+function decryptPublicUser(user: PublicUser): PublicUser {
+  return transformEncryptedFields(user, ['name', 'email', 'phone'], decryptString);
+}
+
+function encryptSession(session: Session): Session {
+  return {
+    ...session,
+    email: session.email ? encryptString(session.email) : undefined,
+    phone: session.phone ? encryptString(session.phone) : undefined,
+    user: session.user ? encryptPublicUser(session.user) : undefined,
+  };
+}
+
+function decryptSession(session: Session): Session {
+  return {
+    ...session,
+    email: session.email ? decryptString(session.email) : undefined,
+    phone: session.phone ? decryptString(session.phone) : undefined,
+    user: session.user ? decryptPublicUser(session.user) : undefined,
+  };
+}
+
 export function getSession(id: string): Session | undefined {
   const session = sessions.get(id);
   if (!session) return undefined;
@@ -44,7 +71,7 @@ export function getSession(id: string): Session | undefined {
     deleteSession(id);
     return undefined;
   }
-  return session;
+  return decryptSession(session);
 }
 
 export function getSessionUserBalance(id: string): number | null {
@@ -66,7 +93,7 @@ export function adjustSessionUserBalance(id: string, delta: number): number | nu
 }
 
 export function saveSession(session: Session): void {
-  sessions.set(session.id, session);
+  sessions.set(session.id, encryptSession(session));
 }
 
 export function deleteSession(id: string): void {

--- a/backend/src/config.ts
+++ b/backend/src/config.ts
@@ -44,6 +44,12 @@ export interface AppConfig {
     healthCacheTtlMs: number;
     activityCacheTtlMs: number;
   };
+  cache: {
+    redisUrl: string;
+    enabled: boolean;
+    balanceCacheTtlSeconds: number;
+    activityCacheTtlSeconds: number;
+  };
   features: {
     enableEscrow: boolean;
     enableRiskScoring: boolean;
@@ -115,6 +121,12 @@ export const config: AppConfig = {
   features: {
     enableEscrow: boolFromEnv(process.env.FEATURE_ESCROW, true),
     enableRiskScoring: boolFromEnv(process.env.FEATURE_RISK_SCORING, true),
+  },
+  cache: {
+    redisUrl: process.env.REDIS_URL || '',
+    enabled: !!process.env.REDIS_URL,
+    balanceCacheTtlSeconds: intFromEnv(process.env.BALANCE_CACHE_TTL_SECONDS, 10),
+    activityCacheTtlSeconds: intFromEnv(process.env.ACTIVITY_CACHE_TTL_SECONDS, 10),
   },
   contracts: {
     simpleCounter: process.env.CONTRACT_SIMPLE_COUNTER || 'CA7JEZGXWTX62LE6HSW7C6DQHDFNEKEFYI2AYNXU67AJPKIKNRINTCHB',

--- a/backend/src/config.ts
+++ b/backend/src/config.ts
@@ -55,6 +55,10 @@ export interface AppConfig {
     /** Browser origin(s) allowed for credentialed CORS (comma-separated). */
     corsOrigins: string[];
   };
+  encryption: {
+    /** AES-256-GCM key used to encrypt PII fields at rest. Must be 32 bytes or derivable to 32 bytes. */
+    key: string;
+  };
 }
 
 const intFromEnv = (value: string | undefined, fallback: number) => {
@@ -128,6 +132,9 @@ export const config: AppConfig = {
       .split(',')
       .map((s) => s.trim())
       .filter(Boolean),
+  },
+  encryption: {
+    key: process.env.DATA_ENCRYPTION_KEY || 'dev-only-change-me-in-production-please-set-DATA_ENCRYPTION_KEY',
   },
 };
 

--- a/backend/src/container.ts
+++ b/backend/src/container.ts
@@ -58,32 +58,32 @@ export function createContainer(): AppContainer {
 
   recurringWorker.start();
 
-  eventBus.subscribe<{ userId: string }>('transfer.created', (event) => {
-    activity.invalidateUser(event.payload.userId);
+  eventBus.subscribe<{ userId: string }>('transfer.created', async (event) => {
+    await activity.invalidateUser(event.payload.userId);
   });
   eventBus.subscribe<{ userId: string; transferId: string; amount: number; recipientName: string }>('transfer.settled', async (event) => {
-    activity.invalidateUser(event.payload.userId);
+    await activity.invalidateUser(event.payload.userId);
     await notifications.notifyTransferSettled(event.payload);
   });
   eventBus.subscribe<{ userId: string; amount: number; recipientName: string; transferId: string; error?: string }>(
     'transfer.failed',
     async (event) => {
-      activity.invalidateUser(event.payload.userId);
+      await activity.invalidateUser(event.payload.userId);
       await notifications.notifyTransferFailed(event.payload);
     },
   );
   eventBus.subscribe<{ userId: string; transferId: string; score: number; flags: string[] }>(
     'transfer.flagged',
     async (event) => {
-      activity.invalidateUser(event.payload.userId);
+      await activity.invalidateUser(event.payload.userId);
       await notifications.notifyFraudFlagged(event.payload);
     },
   );
-  eventBus.subscribe<{ userId: string }>('notification.created', (event) => {
-    activity.invalidateUser(event.payload.userId);
+  eventBus.subscribe<{ userId: string }>('notification.created', async (event) => {
+    await activity.invalidateUser(event.payload.userId);
   });
-  eventBus.subscribe<{ userId: string }>('notification.read', (event) => {
-    activity.invalidateUser(event.payload.userId);
+  eventBus.subscribe<{ userId: string }>('notification.read', async (event) => {
+    await activity.invalidateUser(event.payload.userId);
   });
 
   return {

--- a/backend/src/modules/activity/__tests__/activityService.test.ts
+++ b/backend/src/modules/activity/__tests__/activityService.test.ts
@@ -1,0 +1,70 @@
+import { ActivityService } from '../activityService';
+
+jest.mock('../../../utils/redisCache', () => ({
+  getCachedJson: jest.fn(),
+  setCachedJson: jest.fn(),
+  deleteCachedKeys: jest.fn(),
+}));
+
+const { getCachedJson, setCachedJson, deleteCachedKeys } = jest.requireMock('../../../utils/redisCache') as {
+  getCachedJson: jest.Mock;
+  setCachedJson: jest.Mock;
+  deleteCachedKeys: jest.Mock;
+};
+
+describe('ActivityService Redis caching', () => {
+  const sampleRecord = {
+    id: 'tx1',
+    state: 'settled',
+    amount: 100,
+    recipient: {
+      metadata: { identifier: '+15551234567', name: 'Alice' },
+      type: 'bank',
+      country: 'US',
+    },
+    metadata: { network_fee: 1, service_fee: 2 },
+    createdAt: new Date().toISOString(),
+    statusHistory: [{ state: 'created', at: new Date().toISOString() }],
+  } as any;
+
+  const repository = {
+    listRecentByUserId: jest.fn().mockResolvedValue([sampleRecord]),
+    listByUserId: jest.fn().mockResolvedValue([sampleRecord]),
+  };
+  const notifications = { listByUserId: jest.fn().mockResolvedValue([]) } as any;
+  const exporter = { generateTransactionExcel: jest.fn().mockResolvedValue(Buffer.from('')) } as any;
+
+  let service: ActivityService;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    service = new ActivityService(repository as any, notifications, exporter);
+  });
+
+  it('uses Redis cache for transaction list when available', async () => {
+    getCachedJson.mockResolvedValueOnce([{ id: 'cached-tx', type: 'send' }]);
+
+    const transactions = await service.listTransactions('user-1', 10);
+
+    expect(getCachedJson).toHaveBeenCalledWith('activity:transactions:user-1:10');
+    expect(transactions).toEqual([{ id: 'cached-tx', type: 'send' }]);
+    expect(repository.listRecentByUserId).not.toHaveBeenCalled();
+  });
+
+  it('caches transaction list after load when Redis miss occurs', async () => {
+    getCachedJson.mockResolvedValueOnce(null);
+
+    const transactions = await service.listTransactions('user-1', 10);
+
+    expect(repository.listRecentByUserId).toHaveBeenCalledWith('user-1', 10);
+    expect(setCachedJson).toHaveBeenCalledWith(expect.stringContaining('activity:transactions:user-1:10'), expect.any(Array), expect.any(Number));
+    expect(transactions[0].id).toBe('tx1');
+  });
+
+  it('invalidates Redis transaction and insight caches for a user', async () => {
+    await service.invalidateUser('user-1');
+
+    expect(deleteCachedKeys).toHaveBeenCalledWith('activity:transactions:user-1:*');
+    expect(deleteCachedKeys).toHaveBeenCalledWith('activity:insights:user-1');
+  });
+});

--- a/backend/src/modules/activity/activityService.ts
+++ b/backend/src/modules/activity/activityService.ts
@@ -2,6 +2,11 @@ import { config } from '../../config';
 import type { NotificationService } from '../notifications/notificationService';
 import type { TransferRecord } from '../transfers/domain';
 import type { TransferRepository } from '../transfers/repository';
+import {
+  deleteCachedKeys,
+  getCachedJson,
+  setCachedJson,
+} from '../../utils/redisCache';
 import { ExportService } from './exportService';
 
 export interface ActivityTransactionDto {
@@ -128,10 +133,10 @@ export class ActivityService {
   ) {}
 
   async listTransactions(userId: string, limit = 50): Promise<ActivityTransactionDto[]> {
-    const cacheKey = `${userId}:${limit}`;
-    const cached = this.transactionCache.get(cacheKey);
-    if (cached && cached.expiresAt > Date.now()) {
-      return cached.value;
+    const cacheKey = `activity:transactions:${userId}:${limit}`;
+    const cached = await getCachedJson<ActivityTransactionDto[]>(cacheKey);
+    if (cached) {
+      return cached;
     }
 
     const records = await this.repository.listRecentByUserId(userId, limit);
@@ -140,6 +145,7 @@ export class ActivityService {
       expiresAt: Date.now() + config.performance.activityCacheTtlMs,
       value: transactions,
     });
+    await setCachedJson(cacheKey, transactions, config.cache.activityCacheTtlSeconds);
     return transactions;
   }
 
@@ -268,6 +274,7 @@ export class ActivityService {
       expiresAt: Date.now() + config.performance.activityCacheTtlMs,
       value: insights,
     });
+    await setCachedJson(`activity:insights:${userId}`, insights, config.cache.activityCacheTtlSeconds);
 
     return insights;
   }
@@ -437,11 +444,13 @@ export class ActivityService {
     return this.notifications.listByUserId(userId, limit);
   }
 
-  invalidateUser(userId: string) {
+  async invalidateUser(userId: string) {
     this.insightsCache.delete(userId);
     Array.from(this.transactionCache.keys())
-      .filter((key) => key.startsWith(`${userId}:`))
+      .filter((key) => key.startsWith(`activity:transactions:${userId}:`))
       .forEach((key) => this.transactionCache.delete(key));
+    await deleteCachedKeys(`activity:transactions:${userId}:*`);
+    await deleteCachedKeys(`activity:insights:${userId}`);
   }
 
   private toTransactionDto(record: TransferRecord): ActivityTransactionDto {

--- a/backend/src/routes/auth.ts
+++ b/backend/src/routes/auth.ts
@@ -11,6 +11,7 @@ import {
   saveSession,
 } from '../auth/sessionStore';
 import { authenticate } from '../middleware/authenticate';
+import { deleteCachedKey, getCachedJson, setCachedJson } from '../utils/redisCache';
 
 interface LoginBody {
   identifier: string;
@@ -139,6 +140,7 @@ export default async function authRoutes(fastify: FastifyInstance) {
       session.user = undefined;
     }
     saveSession(session);
+    await deleteCachedKey(`auth:me:${session.id}`);
 
     await setAuthCookie(reply, session);
 
@@ -164,18 +166,34 @@ export default async function authRoutes(fastify: FastifyInstance) {
 
   fastify.get('/auth/me', { preHandler: [authenticate] }, async (request, reply) => {
     const token = request.user as JwtSessionPayload;
+    const cacheKey = `auth:me:${token.sub}`;
+    const cached = await getCachedJson<{
+      authUser: ReturnType<typeof sessionToAuthUser>;
+      session: ReturnType<typeof getSessionInfo>;
+      user: PublicUser | null;
+      onboardingRequired: boolean;
+    }>(cacheKey);
+    if (cached) {
+      reply.header('Cache-Control', 'private, max-age=10');
+      return reply.send(cached);
+    }
+
     const session = getSession(token.sub);
     if (!session) {
       clearAuthCookie(reply);
       return reply.status(401).send({ error: 'Session expired' });
     }
 
-    return reply.send({
+    const response = {
       authUser: sessionToAuthUser(session),
       session: getSessionInfo(session),
       user: session.user ?? null,
       onboardingRequired: session.verified && !session.onboardingCompleted && !session.user,
-    });
+    } as const;
+
+    await setCachedJson(cacheKey, response, config.cache.balanceCacheTtlSeconds);
+    reply.header('Cache-Control', 'private, max-age=10');
+    return reply.send(response);
   });
 
   fastify.post('/auth/session/heartbeat', { preHandler: [authenticate] }, async (request, reply) => {
@@ -223,6 +241,7 @@ export default async function authRoutes(fastify: FastifyInstance) {
     session.hasWallet = true;
     session.onboardingCompleted = true;
     saveSession(session);
+    await deleteCachedKey(`auth:me:${session.id}`);
 
     await setAuthCookie(reply, session);
 

--- a/backend/src/utils/encryption.ts
+++ b/backend/src/utils/encryption.ts
@@ -1,0 +1,61 @@
+import crypto from 'crypto';
+import { config, isProd } from '../config';
+
+const ALGORITHM = 'aes-256-gcm';
+const IV_LENGTH = 12;
+const KEY_LENGTH = 32;
+
+function normalizeKey(rawKey: string): Buffer {
+  const asBuffer = Buffer.from(rawKey, 'utf-8');
+  if (asBuffer.length === KEY_LENGTH) return asBuffer;
+  if (asBuffer.length > KEY_LENGTH) return asBuffer.slice(0, KEY_LENGTH);
+  return crypto.createHash('sha256').update(asBuffer).digest();
+}
+
+function getEncryptionKey(): Buffer {
+  const rawKey = config.encryption.key;
+  if (!rawKey || rawKey.includes('dev-only-change-me-in-production')) {
+    if (isProd()) {
+      throw new Error('DATA_ENCRYPTION_KEY must be set in production for PII at-rest encryption.');
+    }
+  }
+  return normalizeKey(rawKey);
+}
+
+export function encryptString(value: string): string {
+  const iv = crypto.randomBytes(IV_LENGTH);
+  const cipher = crypto.createCipheriv(ALGORITHM, getEncryptionKey(), iv);
+  const encrypted = Buffer.concat([cipher.update(value, 'utf8'), cipher.final()]);
+  const authTag = cipher.getAuthTag();
+  return Buffer.concat([iv, authTag, encrypted]).toString('base64');
+}
+
+export function decryptString(value: string): string {
+  const buffer = Buffer.from(value, 'base64');
+  if (buffer.length < IV_LENGTH + 16) {
+    throw new Error('Invalid encrypted payload');
+  }
+  const iv = buffer.slice(0, IV_LENGTH);
+  const authTag = buffer.slice(IV_LENGTH, IV_LENGTH + 16);
+  const ciphertext = buffer.slice(IV_LENGTH + 16);
+  const decipher = crypto.createDecipheriv(ALGORITHM, getEncryptionKey(), iv);
+  decipher.setAuthTag(authTag);
+  return Buffer.concat([decipher.update(ciphertext), decipher.final()]).toString('utf8');
+}
+
+export function transformEncryptedFields<T extends object>(
+  source: T,
+  fields: Array<keyof T>,
+  transformFn: (value: string) => string,
+): T {
+  return fields.reduce((acc, field) => {
+    const value = acc[field];
+    if (typeof value === 'string' && value.length > 0) {
+      return {
+        ...acc,
+        [field]: transformFn(value),
+      };
+    }
+    return acc;
+  }, source);
+}

--- a/backend/src/utils/redisCache.ts
+++ b/backend/src/utils/redisCache.ts
@@ -1,0 +1,116 @@
+import { createClient, type RedisClientType } from 'redis';
+import { config } from '../config';
+import { logger } from '../logger';
+
+let client: RedisClientType | null = null;
+
+export function createRedisClient(): RedisClientType | null {
+  if (!config.cache.enabled || !config.cache.redisUrl) {
+    return null;
+  }
+  if (client) {
+    return client;
+  }
+
+  client = createClient({
+    url: config.cache.redisUrl,
+    socket: {
+      reconnectStrategy: (retries) => Math.min(retries * 50, 500),
+    },
+  });
+
+  client.on('error', (error) => {
+    logger.error({ err: error }, 'Redis client error');
+  });
+
+  return client;
+}
+
+export async function initRedisClient(): Promise<RedisClientType | null> {
+  const redis = createRedisClient();
+  if (!redis) {
+    return null;
+  }
+  if (!redis.isOpen) {
+    await redis.connect();
+  }
+  return redis;
+}
+
+export async function closeRedisClient(): Promise<void> {
+  if (!client) {
+    return;
+  }
+  try {
+    if (client.isOpen) {
+      await client.disconnect();
+    }
+  } catch (error) {
+    logger.error({ err: error }, 'Error closing Redis client');
+  } finally {
+    client = null;
+  }
+}
+
+export function getRedisClient(): RedisClientType | null {
+  return client;
+}
+
+export async function getCachedJson<T>(key: string): Promise<T | null> {
+  const redis = getRedisClient();
+  if (!redis) {
+    return null;
+  }
+
+  try {
+    const payload = await redis.get(key);
+    if (!payload) {
+      return null;
+    }
+    return JSON.parse(payload) as T;
+  } catch (error) {
+    logger.warn({ err: error, key }, 'Redis read failed');
+    return null;
+  }
+}
+
+export async function setCachedJson(key: string, value: unknown, ttlSeconds: number): Promise<void> {
+  const redis = getRedisClient();
+  if (!redis) {
+    return;
+  }
+
+  try {
+    await redis.set(key, JSON.stringify(value), { EX: ttlSeconds });
+  } catch (error) {
+    logger.warn({ err: error, key }, 'Redis write failed');
+  }
+}
+
+export async function deleteCachedKey(key: string): Promise<void> {
+  const redis = getRedisClient();
+  if (!redis) {
+    return;
+  }
+
+  try {
+    await redis.del(key);
+  } catch (error) {
+    logger.warn({ err: error, key }, 'Redis delete failed');
+  }
+}
+
+export async function deleteCachedKeys(pattern: string): Promise<void> {
+  const redis = getRedisClient();
+  if (!redis) {
+    return;
+  }
+
+  try {
+    for await (const key of redis.scanIterator({ MATCH: pattern, COUNT: 100 })) {
+      await redis.del(key);
+    }
+  } catch (error) {
+    logger.warn({ err: error, pattern }, 'Redis key scan/delete failed');
+  }
+}


### PR DESCRIPTION
Closes #67  

What changed

Added Redis support for API-level caching in the backend.
Cached activity history and spending insights in Redis.
Cached `/auth/me` responses so repeated balance requests are faster.